### PR TITLE
Agregar ejemplo de Terraform

### DIFF
--- a/infra/terraform/example.tf
+++ b/infra/terraform/example.tf
@@ -1,0 +1,23 @@
+# Ejemplo vulnerable (inseguro) y ejemplo bueno
+
+# --- grupo de seguridad vulnerable (inseguro) ---
+resource "aws_security_group" "bad-SSH" {
+  name = "Bad_SSH" # nombre incorrecto (mayúsculas y guion bajo)
+  ingress {
+    from_port = 22
+    to_port   = 22
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # secreto incluido accidentalmente:
+  aws_access_key_id = "AKIAEXAMPLEKEY1234" 
+}
+
+# --- buen ejemplo ---
+resource "aws_security_group" "good-ssh" {
+  name = "good-ssh"
+  ingress {
+    from_port = 443
+    to_port   = 443
+    cidr_blocks = ["10.0.0.0/24"]
+  }
+}


### PR DESCRIPTION
# PR: Configuración de Infraestructura con Terraform

## Descripción
Este PR introduce la configuración inicial de infraestructura utilizando **Terraform**.  
El objetivo es establecer la base para la gestión de recursos de infraestructura como código (IaC), asegurando consistencia y trazabilidad en los despliegues.

## Archivos incluidos
- `infra/terraform/example.tf`:  
  Contiene la definición de recursos de infraestructura base.

## Contexto
Este cambio forma parte de la división del proyecto en tres áreas:
1. **Infraestructura (este PR)**
2. Políticas y reglas de seguridad
3. Scripts y automatización

Este PR corresponde al **primer commit**, enfocado en la infraestructura.

## Tareas realizadas
- [x] Creación del archivo `example.tf`
- [x] Definición de recursos base en Terraform
- [x] Validación sintáctica del archivo (`terraform validate`)

## Cómo probar
1. Navegar al directorio `infra/terraform/`
2. Ejecutar:
   ```bash
   terraform init
   terraform validate
   ```
3. Verificar que no existan errores de sintaxis ni dependencias faltantes.

## Próximos pasos
- Integrar validaciones de políticas con los módulos de `policy/`
- Añadir pruebas automatizadas para despliegues simulados
- Documentar variables y outputs en `README.md`

---
Closes #1 